### PR TITLE
fix: 修复重命名后没有刷新路径导致的崩溃

### DIFF
--- a/src/components/NotoEditor.tsx
+++ b/src/components/NotoEditor.tsx
@@ -144,7 +144,7 @@ const NotoEditor = (props: IDirectoryProps) => {
   // 上一次修改完成之前，不允许再次修改
   const isEditing = useRef<boolean>(false);
 
-  const renameCallback = useCallback(debounce(updateFileName, 450), [updateFileName]);
+  const renameCallback = useCallback(debounce(updateFileName, 450), [filePath, updateFileName]);
 
   useEffect(() => {
     fetchData(filePath);
@@ -179,6 +179,9 @@ const NotoEditor = (props: IDirectoryProps) => {
         onChange={handleFileRename}
         className='py-2 mx-4 text-3xl font-medium focus:outline-0'
         disabled={isEditing.current}
+        autoComplete='off'
+        autoCorrect='off'
+        autoCapitalize='off'
       />
       <div className='flex-1 h-full overflow-y-scroll border-t bg-slate-50'>
         <MilkdownProvider>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -98,12 +98,12 @@ export default function Home() {
   const updateFileName = (oldPath: string, newPath: string) => {
     renameFile(oldPath, newPath).then(res => {
       // 获取修改的文件所在的文件夹绝对路径
-        const dirPath = newPath.replaceAll('\\', '/').split('/').slice(0, -1).join('/');
+      const dirPath = newPath.replaceAll('\\', '/').split('/').slice(0, -1).join('/');
 
       // 获取这个路径相对于 app 根目录的相对路径
       const relativePath = dirPath.replace(dir.path, '');
       // 根据相对路径，找到对应的文件夹对象
-        const pathArr = relativePath.split('/');
+      const pathArr = relativePath.split('/');
       pathArr.shift();
       let currentDir = dir;
       while (pathArr.length > 0) {
@@ -112,8 +112,8 @@ export default function Home() {
       }
 
       fetchDirectory(currentDir);
-    }
-    )
+      setCurrentSelectedPath(res);
+    })
   };
 
   /** 拉取目录下的文件列表 */


### PR DESCRIPTION
重命名以后没有及时更新 currentSelectPath 导致再次重命名时找不到文件崩溃（我也很崩溃）